### PR TITLE
Improve device discovery & modernize component

### DIFF
--- a/custom_components/intesisbox/climate.py
+++ b/custom_components/intesisbox/climate.py
@@ -113,18 +113,22 @@ class IntesisBoxAC(ClimateDevice):
 
         # Setup fan list
         self._fan_list = [x.title() for x in self._controller.fan_speed_list]
+        if len(self._fan_list) < 1:
+          raise PlatformNotReady
         self._fan_speed = None
 
         # Setup operation list
         self._operation_list = [HVAC_MODE_OFF]
         for operation in self._controller.operation_list:
             self._operation_list.append(MAP_OPERATION_MODE_TO_HA[operation])
-        
+        if len(self._operation_list) == 1:
+           raise PlatformNotReady
+
         # Setup feature support
         self._base_features = (SUPPORT_TARGET_TEMPERATURE)
         if len(self._fan_list) > 0:
             self._base_features |= SUPPORT_FAN_MODE
-        
+
         # Setup swing control
         if self._has_swing_control:
             self._base_features |= SUPPORT_SWING_MODE
@@ -134,7 +138,7 @@ class IntesisBoxAC(ClimateDevice):
             if SWING_ON in self._controller.vane_vertical_list:
                 self._swing_list.append(SWING_LIST_VERTICAL)
             if len(self._swing_list) > 2:
-                self._swing_list.append(SWING_LIST_BOTH)            
+                self._swing_list.append(SWING_LIST_BOTH)
 
         self._controller.add_update_callback(self.update_callback)
 
@@ -253,7 +257,7 @@ class IntesisBoxAC(ClimateDevice):
                 _LOGGER.debug("Connection to Intesisbox was restored.")
             else:
                 _LOGGER.debug("Lost connection to Intesisbox.")
-    
+
     async def async_will_remove_from_hass(self):
         """Shutdown the controller when the device is being removed."""
         self._controller.stop()

--- a/custom_components/intesisbox/climate.py
+++ b/custom_components/intesisbox/climate.py
@@ -12,7 +12,7 @@ import voluptuous as vol
 import homeassistant.helpers.config_validation as cv
 
 from homeassistant.components import persistent_notification
-from homeassistant.components.climate import PLATFORM_SCHEMA, ClimateDevice
+from homeassistant.components.climate import PLATFORM_SCHEMA, ClimateEntity
 from homeassistant.components.climate.const import (
     ATTR_HVAC_MODE,
     HVAC_MODE_HEAT_COOL,
@@ -86,7 +86,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     async_add_entities([IntesisBoxAC(controller, name)],True)
 
 
-class IntesisBoxAC(ClimateDevice):
+class IntesisBoxAC(ClimateEntity):
     """Represents an Intesisbox air conditioning device."""
 
     def __init__(self, controller, name):

--- a/custom_components/intesisbox/intesisbox.py
+++ b/custom_components/intesisbox/intesisbox.py
@@ -6,6 +6,7 @@ import queue
 import sys
 from optparse import OptionParser
 from asyncio import ensure_future
+from time import sleep
 
 _LOGGER = logging.getLogger('pyintesisbox')
 
@@ -69,10 +70,15 @@ class IntesisBox(asyncio.Protocol):
         self._transport = transport
 
         self._transport.write("ID\r".encode('ascii'))
+        sleep(1)
         self._transport.write("LIMITS:SETPTEMP\r".encode('ascii'))
+        sleep(1)
         self._transport.write("LIMITS:FANSP\r".encode('ascii'))
+        sleep(1)
         self._transport.write("LIMITS:MODE\r".encode('ascii'))
+        sleep(1)
         self._transport.write("LIMITS:VANEUD\r".encode('ascii'))
+        sleep(1)
         self._transport.write("LIMITS:VANELR\r".encode('ascii'))
 
     def data_received(self, data):
@@ -93,6 +99,7 @@ class IntesisBox(asyncio.Protocol):
                     self._parse_change_received(args)
                 elif cmd == 'LIMITS':
                     self._parse_limits_received(args)
+
         self._send_update_callback()
 
     def _parse_id_received(self, args):
@@ -103,7 +110,7 @@ class IntesisBox(asyncio.Protocol):
             self._mac = info[1]
             self._firmversion = info[4]
             self._rssi = info[5]
-    
+
     def _parse_change_received(self, args):
         function = args.split(',')[0]
         value = args.split(',')[1]
@@ -145,7 +152,7 @@ class IntesisBox(asyncio.Protocol):
                 # Must poll to get the authentication token
                 if self._ip and self._port:
                     # Create asyncio socket
-                    coro = self._eventLoop.create_connection(lambda: self, 
+                    coro = self._eventLoop.create_connection(lambda: self,
                                                              self._ip,
                                                              self._port)
                     _LOGGER.debug('Opening connection to IntesisBox %s:%s',
@@ -198,7 +205,7 @@ class IntesisBox(asyncio.Protocol):
 
         if mode in MODES:
             self._set_value(FUNCTION_MODE, mode)
-        
+
     def set_mode_dry(self):
         """Public method to set device to dry asynchronously."""
         self._set_value(FUNCTION_MODE, MODE_DRY)
@@ -218,7 +225,7 @@ class IntesisBox(asyncio.Protocol):
     @property
     def vane_horizontal_list(self):
         return self._horizontal_vane_list
-        
+
     @property
     def vane_vertical_list(self):
         return self._vertical_vane_list

--- a/custom_components/intesisbox/manifest.json
+++ b/custom_components/intesisbox/manifest.json
@@ -1,6 +1,7 @@
 {
   "domain": "intesisbox",
   "name": "IntesisBox",
+	"version": "0.97",
   "documentation": "https://github.com/jnimmo/hass-intesisbox",
   "dependencies": [],
   "codeowners": ["@jnimmo"],


### PR DESCRIPTION
### Improve device discovery
I think I've hacked together ways to improve the device discovery to limit instances where `hass-intesisbox` gives up providing HA with the individual IntesisBox devices’ capabilities on system start-up. I'm not a Python expert, and not really a programmer at all, so I'd be happy if someone were to improve my code!

- Use `PlatformNotReady` exception in `climate.py`.
- Introduce `sleep(1)` between `LIMITS` commands in `intesisbox.py`.

## Modernize component for latest HA architecture requirements

- Introduce `version` key in `manifest.json` (as required by HA 2021.3 +).
- Change `ClimateDevice` to `ClimateEntity` (as changed in HA in May 2020 or so).

Fixes #5
Fixes #6 (possibly)