### PR TITLE
Config flow

### DIFF
--- a/custom_components/intesisbox/IntesisBoxEmulator.py
+++ b/custom_components/intesisbox/IntesisBoxEmulator.py
@@ -94,4 +94,4 @@ async def main(host, port):
     server = await loop.create_server(IntesisBoxEmulator, host, port)
     await server.serve_forever()
 
-asyncio.run(main('127.0.0.1', 3310))
+asyncio.run(main('0.0.0.0', 3310))

--- a/custom_components/intesisbox/__init__.py
+++ b/custom_components/intesisbox/__init__.py
@@ -1,1 +1,37 @@
 """IntesisBox Climate Platform"""
+
+DOMAIN = "intesisbox"
+PLATFORMS = ["climate"]
+
+import asyncio
+import logging
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_HOST
+from homeassistant.core import HomeAssistant
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Load the saved entities."""
+    host = entry.data[CONF_HOST]
+
+    from . import intesisbox
+    controller = intesisbox.IntesisBox(host, loop=hass.loop)
+    controller.connect()
+    while not controller.is_connected:
+        await asyncio.sleep(0.1)
+
+    hass.data.setdefault(DOMAIN, {})
+    hass.data[DOMAIN][entry.entry_id] = controller
+
+    if entry.unique_id is None:
+        hass.config_entries.async_update_entry(entry, unique_id=controller.device_mac_address)
+
+    hass.config_entries.async_setup_platforms(entry, PLATFORMS)
+
+    return True
+
+async def async_unload_entry(hass, entry):
+    """Unload a config entry."""
+    controller = hass.data[DOMAIN][entry.entry_id]
+    controller.stop()
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)

--- a/custom_components/intesisbox/climate.py
+++ b/custom_components/intesisbox/climate.py
@@ -29,6 +29,7 @@ from homeassistant.const import (
     ATTR_TEMPERATURE,
     CONF_HOST,
     CONF_NAME,
+    CONF_UNIQUE_ID,
     STATE_UNKNOWN,
     TEMP_CELSIUS
     )
@@ -41,6 +42,7 @@ DEFAULT_NAME = 'Intesisbox'
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_HOST): cv.string,
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+    vol.Optional(CONF_UNIQUE_ID): cv.string,
 })
 
 # Return cached results if last scan time was less than this value.
@@ -83,19 +85,21 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
 
     controller.poll_status()
     name = config.get(CONF_NAME)
-    async_add_entities([IntesisBoxAC(controller, name)],True)
+    unique_id = config.get(CONF_UNIQUE_ID)
+    async_add_entities([IntesisBoxAC(controller, name, unique_id)],True)
 
 
 class IntesisBoxAC(ClimateEntity):
     """Represents an Intesisbox air conditioning device."""
 
-    def __init__(self, controller, name):
+    def __init__(self, controller, name, unique_id):
         """Initialize the thermostat."""
         _LOGGER.debug('Added climate device with state')
         self._controller = controller
 
         self._deviceid = controller.device_mac_address
         self._devicename = name
+        self._unique_id = unique_id or controller.device_mac_address
         self._connected = controller.is_connected
 
         self._max_temp = controller.max_setpoint
@@ -146,6 +150,11 @@ class IntesisBoxAC(ClimateEntity):
     def name(self):
         """Return the name of the AC device."""
         return self._devicename
+
+    @property
+    def unique_id(self):
+        """Return the unique id of the AC device."""
+        return self._unique_id
 
     @property
     def temperature_unit(self):

--- a/custom_components/intesisbox/config_flow.py
+++ b/custom_components/intesisbox/config_flow.py
@@ -1,0 +1,58 @@
+"""Config flow to configure the Intesisbox integration."""
+import logging
+
+import voluptuous as vol
+
+from homeassistant import config_entries
+from homeassistant.const import CONF_HOST
+
+from . import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+class IntesisboxFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
+    """Handle a config flow."""
+
+    VERSION = 1
+
+    def __init__(self):
+        """Initialize Intesisbox config flow."""
+        self._host = None
+
+    def _show_setup_form(self, user_input=None, errors=None):
+        """Show the setup form to the user."""
+
+        if user_input is None:
+            user_input = {}
+
+        return self.async_show_form(
+            step_id="user",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(CONF_HOST, default=user_input.get(CONF_HOST, "")): str,
+                }
+            ),
+            errors=errors or {},
+        )
+
+    async def async_step_user(self, user_input=None):
+        """Handle a flow initiated by the user."""
+        errors = {}
+
+        if user_input is None:
+            return self._show_setup_form(user_input, errors)
+
+        self._host = user_input[CONF_HOST]
+
+        # Check if already configured
+        #await self.async_set_unique_id(self._host)
+        #self._abort_if_unique_id_configured()
+
+        return self.async_create_entry(
+            title=self._host,
+            data={CONF_HOST: self._host},
+        )
+
+    async def async_step_import(self, user_input=None):
+        """Import a config entry."""
+        return await self.async_step_user(user_input)

--- a/custom_components/intesisbox/intesisbox.py
+++ b/custom_components/intesisbox/intesisbox.py
@@ -253,6 +253,10 @@ class IntesisBox(asyncio.Protocol):
         return self._model
 
     @property
+    def firmware_version(self) -> str:
+        return self._firmversion
+
+    @property
     def is_on(self) -> bool:
         """Return true if the controlled device is turned on"""
         return self._device.get(FUNCTION_ONOFF) == POWER_ON

--- a/custom_components/intesisbox/manifest.json
+++ b/custom_components/intesisbox/manifest.json
@@ -5,5 +5,6 @@
   "documentation": "https://github.com/jnimmo/hass-intesisbox",
   "dependencies": [],
   "codeowners": ["@jnimmo"],
+  "config_flow": true,
   "requirements": []
 }

--- a/custom_components/intesisbox/translations/en.json
+++ b/custom_components/intesisbox/translations/en.json
@@ -1,0 +1,20 @@
+{
+    "config": {
+        "abort": {
+            "already_configured": "Device is already configured"
+        },
+        "error": {
+            "cannot_connect": "Failed to connect",
+            "unknown": "Unexpected error"
+        },
+        "step": {
+            "user": {
+                "data": {
+                    "host": "Host"
+                },
+                "title": "IntesisBox",
+                "description": "Integration for Intesis Home Automation Interface devices supporting the WMP protocol over the local network"
+            }
+        }
+    }
+}


### PR DESCRIPTION
This change adds the ability to configure the integration via the UI.
It's not super pretty, but it works.
<img width="609" alt="image" src="https://user-images.githubusercontent.com/698597/120054177-884d9780-c082-11eb-842f-49d46e5ebc41.png">

It doesn't break things if you had an entity configured via YAML prior to this version.
But it also doesn't support migration/import of entities, people who want to switch will need to do so manually.

A benefit of configuring through the UI is that we can now easily add a `device_info` property to the climate entity, which results in exposing more of the information of the Intesisbox in home assistant.

The default looks like this
<img width="346" alt="image" src="https://user-images.githubusercontent.com/698597/120054108-19703e80-c082-11eb-93b0-dad59385c56b.png">

And all the normal renaming works as you might expect, allowing users to give things prettier names
<img width="333" alt="image" src="https://user-images.githubusercontent.com/698597/120054148-6227f780-c082-11eb-86f9-ee4accaea708.png">
