### PR TITLE
Python 3.10 support

### DIFF
--- a/custom_components/intesisbox/intesisbox.py
+++ b/custom_components/intesisbox/intesisbox.py
@@ -75,21 +75,21 @@ class IntesisBox(asyncio.Protocol):
         while self.is_connected:
             _LOGGER.debug("Sending keepalive")
             self._transport.write("PING\r".encode('ascii'))
-            await asyncio.sleep(45, loop=self._eventLoop)
+            await asyncio.sleep(45)
         else:
             _LOGGER.debug("Not connected, skipping keepalive")
 
     async def query_initial_state(self):
         self._transport.write("ID\r".encode('ascii'))
-        await asyncio.sleep(1, loop=self._eventLoop)
+        await asyncio.sleep(1)
         self._transport.write("LIMITS:SETPTEMP\r".encode('ascii'))
-        await asyncio.sleep(1, loop=self._eventLoop)
+        await asyncio.sleep(1)
         self._transport.write("LIMITS:FANSP\r".encode('ascii'))
-        await asyncio.sleep(1, loop=self._eventLoop)
+        await asyncio.sleep(1)
         self._transport.write("LIMITS:MODE\r".encode('ascii'))
-        await asyncio.sleep(1, loop=self._eventLoop)
+        await asyncio.sleep(1)
         self._transport.write("LIMITS:VANEUD\r".encode('ascii'))
-        await asyncio.sleep(1, loop=self._eventLoop)
+        await asyncio.sleep(1)
         self._transport.write("LIMITS:VANELR\r".encode('ascii'))
 
     def data_received(self, data):


### PR DESCRIPTION
Home Assistant 2022.7 moves to Python 3.10

Python 3.10 removes the `loop` argument from `asyncio` methods

This PR makes this custom component work again with Home Assistant 2022.7 