### PR TITLE
Handle unsupported ambient temperature

### DIFF
--- a/custom_components/intesisbox/intesisbox.py
+++ b/custom_components/intesisbox/intesisbox.py
@@ -292,6 +292,9 @@ class IntesisBox(asyncio.Protocol):
         temperature = self._device.get(FUNCTION_AMBTEMP)
         if temperature:
             temperature = int(temperature) / 10
+        # When unsupported, -32768 is reported
+        if temperature == -3276.8:
+            temperature = None
         return temperature
 
     @property


### PR DESCRIPTION
Some wall units don't report the ambient temperature, because it's measured at the air return instead of the wall remote.

For example, see the last page of https://cdn.hms-networks.com/docs/librariesprovider11/manuals-design-guides/installation-sheet/ac-cloud-control/inwfifgl001r000-installation-sheet.pdf

In this scenario, the Intesis Box returns `-32768` as the null value.

```
< [Tx]  GET,1:AMBTEMP
> [rx]  CHN,1:AMBTEMP,-32768
```

This change transcribes that magic value to `None` so that HA then shows a sensible UI.