### PR TITLE
add a release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,28 @@
+name: Build
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Get version
+        id: version
+        uses: home-assistant/actions/helpers/version@master
+
+      - name: Patch manifest and zip
+        run: |
+          sed -i 's/v0.0.0/${{ steps.version.outputs.version }}/' custom_components/intesisbox/manifest.json
+          cd custom_components/intesisbox/
+          zip ../../intesisbox.zip -r ./
+
+      - uses: JasonEtco/upload-to-release@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          args: ./intesisbox.zip application/zip

--- a/custom_components/intesisbox/manifest.json
+++ b/custom_components/intesisbox/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "intesisbox",
   "name": "IntesisBox",
-  "version": "0.99",
+  "version": "v0.0.0",
   "documentation": "https://github.com/jnimmo/hass-intesisbox",
   "issue_tracker": "https://github.com/jnimmo/hass-intesisbox/issues",
   "dependencies": [],


### PR DESCRIPTION
Shameless stolen from other custom integrations, this workflow will auto build the component when a release is manually created

![image](https://user-images.githubusercontent.com/698597/227798658-f734c89e-a25d-426d-ae3c-d1270bbf5aa9.png)
