### PR TITLE
fix: use round() instead of int() when encoding setpoint temperature

### DIFF
--- a/custom_components/intesisbox/intesisbox.py
+++ b/custom_components/intesisbox/intesisbox.py
@@ -265,7 +265,7 @@ class IntesisBox(asyncio.Protocol):
 
     def set_temperature(self, setpoint):
         """Public method for setting the temperature."""
-        set_temp = int(setpoint * 10)
+        set_temp = round(setpoint * 10)
         self._set_value(FUNCTION_SETPOINT, set_temp)
 
     def set_fan_speed(self, fan_speed):


### PR DESCRIPTION
### Problem

When Home Assistant is configured in Fahrenheit, it converts the user's setpoint to Celsius before calling `set_temperature()` on the entity (because the entity declares `temperature_unit = CELSIUS`). Most Fahrenheit→Celsius conversions produce repeating decimals:

| User sets | HA passes to set_temperature | `int()` sends | `round()` sends |
|-----------|------------------------------|---------------|-----------------|
| 73 °F | 22.778 °C | 227 (22.7°C) | 228 (22.8°C) ✓ |
| 75 °F | 23.889 °C | 238 (23.8°C) | 239 (23.9°C) ✓ |
| 71 °F | 21.667 °C | 216 (21.6°C) | 217 (21.7°C) ✓ |

`int()` truncates toward zero, so the device consistently receives a value ~0.1°C too low. After the device applies its own internal rounding, it reports back a temperature that may be ~0.2°F below what the user requested. This affects roughly every third Fahrenheit degree.

### Fix

Replace `int(setpoint * 10)` with `round(setpoint * 10)` in `set_temperature()`. This has no effect on Celsius-native use, and correctly rounds the fractional values caused by F→C conversion.

### Testing

Tested on three IntesisBox-controlled mini-split units with HA configured in Fahrenheit. Setpoints now read back correctly after being set.