### PR TITLE
add power sensor tracking to derive hvac_action

### DIFF
--- a/custom_components/intesisbox/__init__.py
+++ b/custom_components/intesisbox/__init__.py
@@ -6,8 +6,14 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant
 
-DOMAIN = "intesisbox"
+from .const import CONF_POWER_SENSOR, CONF_POWER_THRESHOLD, DEFAULT_POWER_THRESHOLD, DOMAIN  # noqa: F401
+
 PLATFORMS = ["climate"]
+
+
+async def _async_options_updated(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Reload integration when options change."""
+    await hass.config_entries.async_reload(entry.entry_id)
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
@@ -30,6 +36,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         )
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+
+    entry.async_on_unload(entry.add_update_listener(_async_options_updated))
 
     return True
 

--- a/custom_components/intesisbox/climate.py
+++ b/custom_components/intesisbox/climate.py
@@ -16,6 +16,7 @@ from homeassistant.components.climate import (
     PLATFORM_SCHEMA,
     ClimateEntity,
     ClimateEntityFeature,
+    HVACAction,
     HVACMode,
 )
 from homeassistant.components.climate.const import ATTR_HVAC_MODE
@@ -24,13 +25,17 @@ from homeassistant.const import (
     CONF_HOST,
     CONF_NAME,
     CONF_UNIQUE_ID,
+    STATE_UNAVAILABLE,
     STATE_UNKNOWN,
     UnitOfTemperature,
 )
+from homeassistant.core import callback
 from homeassistant.exceptions import PlatformNotReady
 import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.event import async_track_state_change_event
 
 from . import DOMAIN
+from .const import CONF_POWER_SENSOR, CONF_POWER_THRESHOLD, DEFAULT_POWER_THRESHOLD
 from .intesisbox import IntesisBox
 
 _LOGGER = logging.getLogger(__name__)
@@ -68,6 +73,13 @@ MAP_STATE_ICONS = {
     HVACMode.FAN_ONLY: "mdi:fan",
 }
 
+MAP_HVAC_MODE_TO_ACTION = {
+    HVACMode.HEAT: HVACAction.HEATING,
+    HVACMode.COOL: HVACAction.COOLING,
+    HVACMode.DRY: HVACAction.DRYING,
+    HVACMode.FAN_ONLY: HVACAction.FAN,
+}
+
 FAN_MODE_I_TO_E = {
     "AUTO": "auto",
     "1": "low",
@@ -102,7 +114,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
 async def async_setup_entry(hass, entry, async_add_entities):
     """Add entries from config."""
     controller = hass.data[DOMAIN][entry.entry_id]
-    async_add_entities([IntesisBoxAC(controller)], True)
+    async_add_entities([IntesisBoxAC(controller, entry=entry)], True)
 
 
 class IntesisBoxAC(ClimateEntity):
@@ -113,10 +125,17 @@ class IntesisBoxAC(ClimateEntity):
         controller: IntesisBox,
         name: str | None = None,
         unique_id: str | None = None,
+        entry=None,
     ):
         """Initialize the thermostat."""
         _LOGGER.debug("Setting up climate device.")
         self._controller = controller
+
+        options = entry.options if entry else {}
+        self._power_sensor_entity_id: str | None = options.get(CONF_POWER_SENSOR)
+        self._power_threshold: float = float(
+            options.get(CONF_POWER_THRESHOLD, DEFAULT_POWER_THRESHOLD)
+        )
 
         self._deviceid = controller.device_mac_address
         self._devicename = name or controller.device_mac_address
@@ -174,6 +193,22 @@ class IntesisBoxAC(ClimateEntity):
         _LOGGER.debug("Finished setting up climate entity!")
         self._controller.add_update_callback(self.update_callback)
 
+    async def async_added_to_hass(self):
+        """Subscribe to power sensor state changes when added to HA."""
+        if self._power_sensor_entity_id:
+            self.async_on_remove(
+                async_track_state_change_event(
+                    self.hass,
+                    [self._power_sensor_entity_id],
+                    self._handle_power_sensor_update,
+                )
+            )
+
+    @callback
+    def _handle_power_sensor_update(self, event):
+        """Update state when the power sensor changes."""
+        self.async_write_ha_state()
+
     @property
     def name(self):
         """Return the name of the AC device."""
@@ -214,6 +249,39 @@ class IntesisBoxAC(ClimateEntity):
             attrs["ha_update_type"] = "poll"
 
         return attrs
+
+    @property
+    def hvac_action(self) -> HVACAction | None:
+        """Return the current HVAC action (heating, cooling, idle, off, etc.)."""
+        if not self._power:
+            return HVACAction.OFF
+
+        if self._power_sensor_entity_id and self.hass:
+            state = self.hass.states.get(self._power_sensor_entity_id)
+            if state is not None and state.state not in (
+                STATE_UNKNOWN,
+                STATE_UNAVAILABLE,
+                "",
+            ):
+                try:
+                    is_running = float(state.state) >= self._power_threshold
+                except (ValueError, TypeError):
+                    is_running = None
+
+                if is_running is False:
+                    return HVACAction.IDLE
+
+        # For HEAT_COOL (auto) mode, infer heating/cooling from temperature delta.
+        if self._current_operation == HVACMode.HEAT_COOL:
+            if self._current_temp is not None and self._target_temperature is not None:
+                return (
+                    HVACAction.HEATING
+                    if self._current_temp < self._target_temperature
+                    else HVACAction.COOLING
+                )
+            return None
+
+        return MAP_HVAC_MODE_TO_ACTION.get(self._current_operation)
 
     def set_temperature(self, **kwargs):
         """Set new target temperature."""

--- a/custom_components/intesisbox/config_flow.py
+++ b/custom_components/intesisbox/config_flow.py
@@ -6,8 +6,16 @@ import voluptuous as vol
 
 from homeassistant import config_entries
 from homeassistant.const import CONF_HOST
+from homeassistant.helpers.selector import (
+    EntitySelector,
+    EntitySelectorConfig,
+    NumberSelector,
+    NumberSelectorConfig,
+    NumberSelectorMode,
+)
 
 from . import DOMAIN
+from .const import CONF_POWER_SENSOR, CONF_POWER_THRESHOLD, DEFAULT_POWER_THRESHOLD
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -20,6 +28,11 @@ class IntesisboxFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):  # type:i
     def __init__(self):
         """Initialize Intesisbox config flow."""
         self._host = None
+
+    @staticmethod
+    def async_get_options_flow(config_entry):
+        """Return the options flow handler."""
+        return IntesisboxOptionsFlowHandler(config_entry)
 
     def _show_setup_form(self, user_input=None, errors=None):
         """Show the setup form to the user."""
@@ -58,3 +71,47 @@ class IntesisboxFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):  # type:i
     async def async_step_import(self, user_input=None):
         """Import a config entry."""
         return await self.async_step_user(user_input)
+
+
+class IntesisboxOptionsFlowHandler(config_entries.OptionsFlow):
+    """Handle Intesisbox options."""
+
+    def __init__(self, config_entry):
+        """Initialize options flow."""
+        self._config_entry = config_entry
+
+    async def async_step_init(self, user_input=None):
+        """Manage the options."""
+        if user_input is not None:
+            return self.async_create_entry(title="", data=user_input)
+
+        current = self._config_entry.options
+        return self.async_show_form(
+            step_id="init",
+            data_schema=vol.Schema(
+                {
+                    vol.Optional(
+                        CONF_POWER_SENSOR,
+                        description={
+                            "suggested_value": current.get(CONF_POWER_SENSOR)
+                        },
+                    ): EntitySelector(
+                        EntitySelectorConfig(domain="sensor", device_class="power")
+                    ),
+                    vol.Optional(
+                        CONF_POWER_THRESHOLD,
+                        default=current.get(
+                            CONF_POWER_THRESHOLD, DEFAULT_POWER_THRESHOLD
+                        ),
+                    ): NumberSelector(
+                        NumberSelectorConfig(
+                            min=0,
+                            max=10000,
+                            step=0.1,
+                            unit_of_measurement="W",
+                            mode=NumberSelectorMode.BOX,
+                        )
+                    ),
+                }
+            ),
+        )

--- a/custom_components/intesisbox/const.py
+++ b/custom_components/intesisbox/const.py
@@ -1,0 +1,7 @@
+"""Constants for the IntesisBox integration."""
+
+DOMAIN = "intesisbox"
+
+CONF_POWER_SENSOR = "power_sensor"
+CONF_POWER_THRESHOLD = "power_threshold"
+DEFAULT_POWER_THRESHOLD = 50.0

--- a/custom_components/intesisbox/translations/en.json
+++ b/custom_components/intesisbox/translations/en.json
@@ -16,5 +16,21 @@
         "description": "Integration for Intesis Home Automation Interface devices supporting the WMP protocol over the local network"
       }
     }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "IntesisBox Options",
+        "description": "Optionally select a power sensor to determine whether the AC unit is actively running.",
+        "data": {
+          "power_sensor": "Power sensor entity",
+          "power_threshold": "Running threshold (W)"
+        },
+        "data_description": {
+          "power_sensor": "A sensor with device class 'power' used to detect active operation.",
+          "power_threshold": "Power draw (in watts) above which the unit is considered actively running."
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
Adds an optional config entry options flow allowing users to select a power sensor (device class: power) and a wattage threshold. When configured, the climate entity uses the sensor reading to distinguish between idle and actively running states, surfacing this via the standard hvac_action property (heating/cooling/drying/fan/idle/off).

For HEAT_COOL (auto) mode, heating vs. cooling is inferred by comparing current temperature to the setpoint when no power sensor is available.

- Add const.py with CONF_POWER_SENSOR, CONF_POWER_THRESHOLD constants
- Add OptionsFlowHandler with EntitySelector and NumberSelector fields
- Register options update listener to reload on change
- Implement hvac_action property on IntesisBoxAC
- Subscribe to power sensor state changes via async_track_state_change_event
- Update translations with options step labels