### PR TITLE
Send the keepalive, own the background tasks, and reconnect with backoff

### DIFF
--- a/custom_components/intesisbox/intesisbox.py
+++ b/custom_components/intesisbox/intesisbox.py
@@ -39,17 +39,39 @@ NULL_VALUES = ["-32768", "32768"]
 # the device sends is a LIMITS list, well under a hundred bytes.
 MAX_LINE_LENGTH = 1024
 
+# The WMP spec says the device closes the TCP connection after 1 minute
+# without traffic, and recommends a keepalive every 30-60 s.
+KEEPALIVE_INTERVAL = 45
+# Full status refresh. Changes arrive spontaneously as CHN messages, so this is
+# only a backstop against missed pushes.
+STATUS_POLL_INTERVAL = 60 * 5
+# Ambient temperature is pushed on change, but poll it as well so a missed push
+# cannot leave the reported temperature stale indefinitely.
+AMBTEMP_POLL_INTERVAL = 60
+
+# The spec requires more than 1 second between opening and closing TCP sockets.
+# Backoff starts there and grows to avoid hammering a device that is off.
+RECONNECT_MIN_DELAY = 1.5
+RECONNECT_MAX_DELAY = 60
+
+# How long a freshly opened socket may go without answering ID before it is
+# closed and the reconnect backoff grows.
+CONNECT_TIMEOUT = 15
+
 background_tasks = set()
 
 
 def clean_background_task(task):
-    """Handle background task completion."""
+    """Handle background task completion, logging any unexpected failure."""
     background_tasks.discard(task)
-    _ = task.result()  # to propagate exceptions
+    if task.cancelled():
+        return
+    if exc := task.exception():
+        _LOGGER.error("Background task failed: %r", exc)
 
 
 def ensure_background_task(coro, loop):
-    """Ensure background task is running."""
+    """Schedule a coroutine on the given loop and keep a reference to it."""
     task = asyncio.ensure_future(coro, loop=loop)
     background_tasks.add(task)
     task.add_done_callback(clean_background_task)
@@ -80,6 +102,17 @@ class IntesisBox(asyncio.Protocol):
         # carry a partial line, several lines, or both.
         self._buffer = b""
 
+        # Set once the device has answered ID on the current connection.
+        self._connected = asyncio.Event()
+
+        # Owned tasks by name, cancelled and replaced on every (re)connect.
+        self._tasks: dict[str, asyncio.Task] = {}
+        self._stopped = False
+
+        # Reconnect backoff, held on the instance so it survives the reconnect
+        # task being cancelled and restarted by connection_lost.
+        self._reconnect_delay = RECONNECT_MIN_DELAY
+
         # Limits
         self._operation_list: list[str] = []
         self._fan_speed_list: list[str] = []
@@ -88,29 +121,234 @@ class IntesisBox(asyncio.Protocol):
         self._setpoint_minimum: float | None = None
         self._setpoint_maximum: float | None = None
 
+    # ------------------------------------------------------------------
+    # Task ownership
+    # ------------------------------------------------------------------
+
+    def _start_task(self, name: str, coro) -> None:
+        """Start a named task, cancelling any previous instance first.
+
+        Without this, a reconnect that lands inside a poller's sleep leaves the
+        old task alive alongside the new one and the traffic doubles each time.
+        """
+        self._cancel_task(name)
+        self._tasks[name] = ensure_background_task(coro, self._eventLoop)
+
+    def _cancel_task(self, name: str) -> None:
+        """Cancel a named task if it is running."""
+        task = self._tasks.pop(name, None)
+        if task and not task.done():
+            task.cancel()
+
+    def _cancel_all_tasks(self) -> None:
+        """Cancel every owned task."""
+        for name in list(self._tasks):
+            self._cancel_task(name)
+
+    # ------------------------------------------------------------------
+    # Connection lifecycle
+    # ------------------------------------------------------------------
+
     def connection_made(self, transport: asyncio.BaseTransport):
         """Asyncio callback for a successful connection."""
-        _LOGGER.debug("Connected to IntesisBox")
-        self._transport = transport
-        ensure_background_task(self.query_initial_state(), self._eventLoop)
+        _LOGGER.debug("Connected to IntesisBox %s:%s", self._ip, self._port)
+        self._transport = transport  # type: ignore[assignment]
+        self._buffer = b""
+        self._connectionStatus = API_CONNECTING
+        self._connected.clear()
+        self._start_task("init", self.query_initial_state())
+
+    def _become_connected(self) -> None:
+        """Mark the device connected and start the periodic tasks."""
+        self._connectionStatus = API_AUTHENTICATED
+        self._reconnect_delay = RECONNECT_MIN_DELAY
+        self._connected.set()
+        _LOGGER.debug("IntesisBox %s connected", self._ip)
+        # Availability just changed; tell the entities rather than leaving
+        # them to notice on the next status push.
+        self._send_update_callback()
+        # Only ever one of each, however many times we reconnect.
+        self._start_task("keepalive", self.keep_alive())
+        self._start_task("poll_status", self.poll_status())
+        self._start_task("poll_ambtemp", self.poll_ambtemp())
+
+    def connection_lost(self, exc):
+        """Asyncio callback for a lost TCP connection."""
+        if exc:
+            _LOGGER.warning("Connection to IntesisBox %s lost: %r", self._ip, exc)
+        else:
+            _LOGGER.info("IntesisBox %s closed the connection", self._ip)
+
+        # A drop before the handshake completed is a failed attempt: grow the
+        # backoff here, because cancelling the reconnect task below would
+        # otherwise reset it to the minimum on every accept-then-drop cycle.
+        # A deliberate stop is neither a success nor a failure.
+        if self._stopped:
+            pass
+        elif self._connectionStatus == API_AUTHENTICATED:
+            self._reconnect_delay = RECONNECT_MIN_DELAY
+        else:
+            self._reconnect_delay = min(self._reconnect_delay * 2, RECONNECT_MAX_DELAY)
+
+        self._connectionStatus = API_DISCONNECTED
+        self._transport = None
+        self._connected.clear()
+        self._cancel_all_tasks()
+        self._send_update_callback()
+
+        if not self._stopped:
+            self._schedule_reconnect()
+
+    def _schedule_reconnect(self) -> None:
+        """Start the reconnect loop if it is not already running."""
+        task = self._tasks.get("reconnect")
+        if task and not task.done():
+            return
+        self._tasks["reconnect"] = ensure_background_task(
+            self._reconnect_loop(), self._eventLoop
+        )
+
+    async def _reconnect_loop(self) -> None:
+        """Reconnect with exponential backoff until the device answers.
+
+        The backoff lives on the instance rather than in a local: closing a
+        half-open transport below fires connection_lost, which cancels and
+        restarts this task, and a local delay would restart at the minimum.
+        """
+        while not self._stopped and not self.is_connected:
+            await asyncio.sleep(self._reconnect_delay)
+            if self._stopped or self.is_connected:
+                return
+            try:
+                await self._open_connection()
+            except (OSError, TimeoutError) as exc:
+                _LOGGER.debug("Reconnect to %s failed: %r", self._ip, exc)
+                self._reconnect_delay = min(
+                    self._reconnect_delay * 2, RECONNECT_MAX_DELAY
+                )
+                continue
+            # A socket that opens but never answers ID is not a usable device.
+            try:
+                async with asyncio.timeout(CONNECT_TIMEOUT):
+                    await self._connected.wait()
+            except TimeoutError:
+                _LOGGER.debug("IntesisBox %s connected but did not answer", self._ip)
+                # connection_lost grows the backoff for this failed attempt.
+                self._close_transport()
+                continue
+            _LOGGER.info("Reconnected to IntesisBox %s", self._ip)
+            return
+
+    async def _open_connection(self) -> None:
+        """Open the TCP connection. Raises OSError or TimeoutError on failure."""
+        if not self._ip or not self._port:
+            raise OSError("Missing IP address or port")
+        self._connectionStatus = API_CONNECTING
+        _LOGGER.debug("Opening connection to IntesisBox %s:%s", self._ip, self._port)
+        try:
+            # A host that drops SYNs rather than refusing can hold a connect
+            # for minutes; bound it the same way as the handshake.
+            async with asyncio.timeout(CONNECT_TIMEOUT):
+                await self._eventLoop.create_connection(
+                    lambda: self, self._ip, self._port
+                )
+        except (OSError, TimeoutError):
+            # Reset the status, otherwise every later attempt sees CONNECTING
+            # and refuses to try again.
+            self._connectionStatus = API_DISCONNECTED
+            raise
+
+    def _attempt_in_progress(self) -> bool:
+        """Whether a socket is open or another connect or reconnect task is live."""
+        if self._transport is not None:
+            return True
+        current = asyncio.current_task()
+        for name in ("connect", "reconnect"):
+            task = self._tasks.get(name)
+            if task is not None and not task.done() and task is not current:
+                return True
+        return False
+
+    async def async_connect(self, timeout: float = 30) -> bool:
+        """Connect and wait until the device has answered ID.
+
+        Returns True once connected, False if the device could not be reached
+        or did not identify itself within the timeout. Either failure leaves
+        the reconnect loop running. If an attempt is already under way this
+        joins it rather than opening a second socket.
+        """
+        self._stopped = False
+        if self.is_connected:
+            return True
+        if not self._attempt_in_progress():
+            try:
+                await self._open_connection()
+            except (OSError, TimeoutError) as exc:
+                _LOGGER.debug("Connection to %s failed: %r", self._ip, exc)
+                self._schedule_reconnect()
+                return False
+        try:
+            async with asyncio.timeout(timeout):
+                await self._connected.wait()
+        except TimeoutError:
+            _LOGGER.debug("IntesisBox %s did not answer ID", self._ip)
+            self._close_transport()
+            self._schedule_reconnect()
+            return False
+        return True
+
+    def connect(self):
+        """Connect to the device, from any thread. A no-op while connected."""
+        if self.is_connected:
+            return
+        self._eventLoop.call_soon_threadsafe(self._ensure_connecting)
+
+    def _ensure_connecting(self) -> None:
+        """Start a connection attempt unless one is already under way.
+
+        Runs on the event loop, so its ordering against stop() is fixed.
+        """
+        self._stopped = False
+        if self.is_connected or self._attempt_in_progress():
+            return
+        self._start_task("connect", self.async_connect())
+
+    def _close_transport(self) -> None:
+        """Close the transport if there is one."""
+        if self._transport is not None and not self._transport.is_closing():
+            self._transport.close()
+
+    def stop(self):
+        """Shut down connectivity with the device and cancel all tasks."""
+        self._stopped = True
+        self._connectionStatus = API_DISCONNECTED
+        self._connected.clear()
+        self._cancel_all_tasks()
+        self._close_transport()
+        self._transport = None
+
+    # ------------------------------------------------------------------
+    # Outbound commands
+    # ------------------------------------------------------------------
 
     async def keep_alive(self):
-        """Send a keepalive command to reset it's watchdog timer."""
-        while self.is_connected:
+        """Send PING periodically to reset the device's watchdog timer."""
+        while True:
+            await asyncio.sleep(KEEPALIVE_INTERVAL)
             _LOGGER.debug("Sending keepalive")
             self._write("PING")
-            await asyncio.sleep(45)
-        else:
-            _LOGGER.debug("Not connected, skipping keepalive")
+
+    async def poll_status(self):
+        """Periodically request a full status refresh."""
+        while True:
+            self._write("GET,1:*")
+            await asyncio.sleep(STATUS_POLL_INTERVAL)
 
     async def poll_ambtemp(self):
-        """Retrieve Ambient Temperature to prevent integration timeouts."""
-        while self.is_connected:
-            _LOGGER.debug("Sending AMBTEMP")
-            self._write("GET,1:AMBTEMP")
-            await asyncio.sleep(10)
-        else:
-            _LOGGER.debug("Not connected, skipping Ambient Temp Request")
+        """Periodically refresh the ambient temperature."""
+        while True:
+            await asyncio.sleep(AMBTEMP_POLL_INTERVAL)
+            self._write(f"GET,1:{FUNCTION_AMBTEMP}")
 
     async def query_initial_state(self):
         """Fetch configuration from the device upon connection."""
@@ -127,13 +365,16 @@ class IntesisBox(asyncio.Protocol):
             await asyncio.sleep(1)
 
     def _write(self, cmd):
-        self._transport.write(f"{cmd}\r".encode("ascii"))
-        _LOGGER.debug(f"Data sent: {cmd!r}")
+        transport = self._transport
+        if transport is None or transport.is_closing():
+            _LOGGER.debug("Dropping %r, transport is gone", cmd)
+            return
+        transport.write(f"{cmd}\r".encode("ascii"))
+        _LOGGER.debug("Data sent: %r", cmd)
 
     async def _writeasync(self, cmd):
         """Async write to slow down commands and await response from units."""
-        self._transport.write(f"{cmd}\r".encode("ascii"))
-        _LOGGER.debug(f"Data sent: {cmd!r}")
+        self._write(cmd)
         await asyncio.sleep(1)
 
     def data_received(self, data: bytes):
@@ -179,11 +420,8 @@ class IntesisBox(asyncio.Protocol):
             return False
         cmd, args = cmdList
         if cmd == "ID":
-            if not self._parse_id_received(args):
-                return False
-            self._connectionStatus = API_AUTHENTICATED
-            ensure_background_task(self.poll_status(), self._eventLoop)
-            ensure_background_task(self.poll_ambtemp(), self._eventLoop)
+            if self._parse_id_received(args):
+                self._become_connected()
             return False
         if cmd == "CHN,1":
             return self._parse_change_received(args)
@@ -276,58 +514,6 @@ class IntesisBox(asyncio.Protocol):
             self._horizontal_vane_list,
         )
         return True
-
-    def connection_lost(self, exc):
-        """Asyncio callback for a lost TCP connection."""
-        self._connectionStatus = API_DISCONNECTED
-        _LOGGER.info("The server closed the connection")
-        self._send_update_callback()
-
-    def connect(self):
-        """Public method for connecting to IntesisHome API."""
-        if self._connectionStatus == API_DISCONNECTED:
-            self._connectionStatus = API_CONNECTING
-            try:
-                # Must poll to get the authentication token
-                if self._ip and self._port:
-                    # Create asyncio socket
-                    coro = self._eventLoop.create_connection(
-                        lambda: self, self._ip, self._port
-                    )
-                    _LOGGER.debug(
-                        "Opening connection to IntesisBox %s:%s", self._ip, self._port
-                    )
-                    ensure_background_task(coro, self._eventLoop)
-                else:
-                    _LOGGER.debug("Missing IP address or port.")
-                    self._connectionStatus = API_DISCONNECTED
-
-            except Exception as e:
-                _LOGGER.error("%s Exception. %s / %s", type(e), repr(e.args), e)
-                self._connectionStatus = API_DISCONNECTED
-        elif self._connectionStatus == API_CONNECTING:
-            _LOGGER.debug("connect() called but already connecting")
-            if self._transport.is_closing():
-                _LOGGER.debug(
-                    "Socket is closing while trying to connect. Force reconnection"
-                )
-                self._connectionStatus = API_DISCONNECTED
-                self._transport.close()
-                self._send_update_callback()
-
-    def stop(self):
-        """Public method for shutting down connectivity with the envisalink."""
-        self._connectionStatus = API_DISCONNECTED
-        self._transport.close()
-
-    async def poll_status(self, sendcallback=False):
-        """Periodically poll for updates since the controllers don't always update reliably."""
-        while self.is_connected:
-            _LOGGER.debug("Polling for update")
-            self._write("GET,1:*")
-            await asyncio.sleep(60 * 5)  # 5 minutes
-        else:
-            _LOGGER.debug("Not connected, skipping poll_status()")
 
     def set_temperature(self, setpoint):
         """Public method for setting the temperature."""

--- a/tests/emulator.py
+++ b/tests/emulator.py
@@ -44,6 +44,10 @@ class Emulator(asyncio.Protocol):
     tear_frames = False
     #: Which ID banner to report.
     id_banner = ID_GEN1
+    #: Accept the connection and answer nothing at all.
+    silent = False
+    #: Live connections, so a test can drop them.
+    connections: list[Emulator] = []
 
     def __init__(self) -> None:
         """Start with a fresh copy of the default device state."""
@@ -55,16 +59,28 @@ class Emulator(asyncio.Protocol):
         """Return the class-level knobs to their defaults."""
         cls.tear_frames = False
         cls.id_banner = ID_GEN1
+        cls.silent = False
+        cls.connections = []
+
+    @classmethod
+    def drop_all(cls) -> None:
+        """Close every live connection, as the device's watchdog would."""
+        for conn in list(cls.connections):
+            conn.transport.close()
+        cls.connections = []
 
     def connection_made(self, transport):
-        """Start the connection's writer."""
+        """Register the connection and start its writer."""
         self.transport = transport
         self._outbox: asyncio.Queue[bytes] = asyncio.Queue()
         self._writer = asyncio.get_running_loop().create_task(self._drain())
+        Emulator.connections.append(self)
 
     def connection_lost(self, exc):
-        """Stop the writer."""
+        """Stop the writer and forget the connection."""
         self._writer.cancel()
+        if self in Emulator.connections:
+            Emulator.connections.remove(self)
 
     def send(self, text: str) -> None:
         """Queue a response for the writer."""
@@ -106,6 +122,8 @@ class Emulator(asyncio.Protocol):
 
     def handle(self, line: str) -> None:
         """Respond to one command."""
+        if Emulator.silent:
+            return
         head = line.split(",")[0]
 
         if line == "ID":

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -244,3 +244,197 @@ def test_short_id_reply_does_not_count_as_connected(caplog):
     assert box.device_mac_address is None
     assert not box.is_connected
     assert not intesisbox.background_tasks
+
+
+# --------------------------------------------------------------------------
+# Keepalive, reconnect and task lifecycle
+# --------------------------------------------------------------------------
+
+
+class FakeTransport:
+    """Stands in for asyncio's transport so the periodic tasks can be observed."""
+
+    def __init__(self) -> None:
+        self.written: list[bytes] = []
+        self.closed = False
+
+    def write(self, data: bytes) -> None:
+        self.written.append(data)
+
+    def is_closing(self) -> bool:
+        return self.closed
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def _live_tasks(box: Any) -> list[str]:
+    return sorted(name for name, task in box._tasks.items() if not task.done())
+
+
+async def test_periodic_tasks_send_keepalive_and_polls(monkeypatch):
+    """PING must actually go out, alongside the status and temperature polls."""
+    monkeypatch.setattr(intesisbox, "KEEPALIVE_INTERVAL", 0.05)
+    monkeypatch.setattr(intesisbox, "AMBTEMP_POLL_INTERVAL", 0.05)
+    box = intesisbox.IntesisBox("127.0.0.1", 1, loop=asyncio.get_running_loop())
+    transport = FakeTransport()
+    box.connection_made(transport)
+    box.data_received(f"{ID_V6}\r\n".encode())
+    await asyncio.sleep(0.3)
+    try:
+        assert b"PING\r" in transport.written
+        assert b"GET,1:AMBTEMP\r" in transport.written
+        assert b"GET,1:*\r" in transport.written
+    finally:
+        await _shutdown(box)
+
+
+async def test_reconnect_does_not_duplicate_pollers(port):
+    """Reconnecting must replace the periodic tasks, not add to them."""
+    box = await _connect_and_handshake(port)
+    try:
+        Emulator.drop_all()
+        await _wait_until(lambda: not box.is_connected, timeout=5)
+
+        await _wait_until(lambda: box.is_connected, timeout=30)
+        # Let the handshake and the retired reconnect task finish.
+        await _wait_until(
+            lambda: not {"reconnect", "init"} & set(_live_tasks(box)), timeout=15
+        )
+        assert _live_tasks(box) == ["keepalive", "poll_ambtemp", "poll_status"]
+    finally:
+        await _shutdown(box)
+
+
+async def test_failed_connection_does_not_wedge_reconnect(port):
+    """A failed first attempt must reset state instead of raising later.
+
+    Previously the status stayed at CONNECTING and the next connect() hit
+    AttributeError on a None transport, permanently breaking reconnection.
+    """
+    box = intesisbox.IntesisBox("127.0.0.1", 1, loop=asyncio.get_running_loop())
+    assert await box.async_connect(timeout=3) is False
+    assert box.is_disconnected
+    box.stop()
+
+    box._port = port
+    assert await box.async_connect(timeout=15)
+    await _shutdown(box)
+
+
+async def test_stop_cancels_all_tasks(port):
+    """stop() must leave nothing running, and must not raise without a socket."""
+    box = await _connect_and_handshake(port)
+    box.stop()
+    await asyncio.sleep(0.1)
+    assert all(task.done() for task in box._tasks.values())
+    assert not box.is_connected
+    box.stop()  # a second stop, with no transport, is harmless
+    await _reap_tasks()
+
+
+async def test_silent_device_times_out_the_handshake(monkeypatch, port):
+    """A box that accepts TCP and never answers must not count as connected."""
+    monkeypatch.setattr(intesisbox, "CONNECT_TIMEOUT", 0.3)
+    Emulator.silent = True
+    box = intesisbox.IntesisBox("127.0.0.1", port, loop=asyncio.get_running_loop())
+    try:
+        assert await box.async_connect(timeout=0.5) is False
+        assert not box.is_connected
+        # The reconnect loop now owns the retry; let it hit the same wall once.
+        box._reconnect_delay = 0.05
+        await asyncio.sleep(1.2)
+        assert not box.is_connected
+        assert box._reconnect_delay > 0.05, "a failed handshake must grow the backoff"
+    finally:
+        await _shutdown(box)
+
+
+async def test_reconnect_backs_off_while_the_device_is_unreachable():
+    box = intesisbox.IntesisBox("127.0.0.1", 1, loop=asyncio.get_running_loop())
+    box._reconnect_delay = 0.05
+    box._schedule_reconnect()
+    await asyncio.sleep(0.5)
+    try:
+        assert box._reconnect_delay > 0.05
+        assert not box.is_connected
+    finally:
+        await _shutdown(box)
+
+
+async def test_connection_lost_after_stop_does_not_reconnect():
+    box = intesisbox.IntesisBox("127.0.0.1", 1, loop=asyncio.get_running_loop())
+    box.stop()
+    box.connection_lost(OSError("reset"))
+    assert "reconnect" not in box._tasks
+    await _reap_tasks()
+
+
+async def test_missing_address_is_a_connection_failure():
+    box = intesisbox.IntesisBox("", 0, loop=asyncio.get_running_loop())
+    assert await box.async_connect(timeout=1) is False
+    await _shutdown(box)
+
+
+async def test_connect_is_idempotent_and_safe_from_another_thread(port):
+    """connect() may be called from an executor thread; a second call is a no-op."""
+    loop = asyncio.get_running_loop()
+    box = intesisbox.IntesisBox("127.0.0.1", port, loop=loop)
+    try:
+        await loop.run_in_executor(None, box.connect)
+        await _wait_until(lambda: box.is_connected)
+        assert await box.async_connect(timeout=1) is True
+        box.connect()
+        await asyncio.sleep(0.2)
+        assert len(Emulator.connections) == 1
+    finally:
+        await _shutdown(box)
+
+
+async def test_write_is_dropped_when_the_transport_is_gone(caplog):
+    box = intesisbox.IntesisBox("127.0.0.1", 1, loop=asyncio.get_running_loop())
+    with caplog.at_level(logging.DEBUG, logger="intesisbox"):
+        box._write("PING")
+    assert "Dropping" in caplog.text
+
+
+async def test_background_task_failures_are_logged(caplog):
+    async def boom():
+        raise RuntimeError("task blew up")
+
+    with caplog.at_level(logging.ERROR):
+        task = intesisbox.ensure_background_task(boom(), asyncio.get_running_loop())
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+    assert task.done()
+    assert "Background task failed" in caplog.text
+
+
+async def test_two_connect_calls_open_one_socket(port):
+    """A second connect() while the first is still opening must join it."""
+    loop = asyncio.get_running_loop()
+    box = intesisbox.IntesisBox("127.0.0.1", port, loop=loop)
+    try:
+        box.connect()
+        box.connect()
+        await loop.run_in_executor(None, box.connect)
+        await _wait_until(lambda: box.is_connected)
+        await asyncio.sleep(0.2)
+        assert len(Emulator.connections) == 1
+    finally:
+        await _shutdown(box)
+
+
+async def test_stop_cancels_a_connect_still_in_flight(monkeypatch, port):
+    """stop() during a pending connect must not let a socket appear later."""
+    monkeypatch.setattr(intesisbox, "CONNECT_TIMEOUT", 5)
+    Emulator.silent = True
+    box = intesisbox.IntesisBox("127.0.0.1", port, loop=asyncio.get_running_loop())
+    box.connect()
+    await _wait_until(lambda: box._transport is not None)
+    box.stop()
+    await asyncio.sleep(0.3)
+    assert all(task.done() for task in box._tasks.values())
+    assert not box.is_connected
+    assert Emulator.connections == []
+    await _reap_tasks()


### PR DESCRIPTION
The rest of #50. Three fixes in one PR because they're the same lifecycle code.

*Keepalive*

`keep_alive()` is defined and never called, so `PING` never goes out. The only thing holding the socket open was the 10 second `GET,1:AMBTEMP` poll doing keepalive duty by accident, and the spec says the device closes the connection after a minute without traffic, so anything that slowed that poll dropped the socket. `PING` now goes every 45 seconds, inside the 30 to 60 second window the spec recommends. The temperature poll drops to every 60 seconds; the device pushes every change itself, so the poll only covers a missed push.

*Duplicate pollers*

`poll_status()` and `poll_ambtemp()` are spawned on every `ID:` reply, and each only checks `is_connected` when its sleep ends, 10 seconds and 5 minutes later. If the connection is back by then, the old task carries on next to the new one. Against the emulator, one drop and reconnect leaves two of each running; every further reconnect adds another pair. Tasks are now named and owned by the controller: starting one cancels its predecessor, losing the connection cancels them all, and `stop()` leaves nothing running.

*Recovery*

After a drop, the entity retries once about five seconds later and then on its five minute poll. A failed attempt leaves the status at `CONNECTING`, so the next call only resets it and the one after that connects, which makes it roughly one real attempt every five minutes. The thread on #50 is people reloading the integration instead of waiting. If the device has never connected in the controller's lifetime, a failed attempt also leaves `_transport` at `None`, and the next `connect()` raises `AttributeError` on `self._transport.is_closing()`.

`connection_lost()` now starts a reconnect loop with exponential backoff, from the spec's one second floor up to a minute, until the device answers `ID`; a socket that opens and never identifies itself is closed and counts as a failed attempt. Every failure path resets the status. Writes with no transport are dropped with a debug line. `stop()` is safe without a socket and cancels an attempt still in flight. `connect()` can be called from any thread, as the entity does from its executor, and a call while a connection is up or an attempt is under way joins that attempt. The TCP connect has the same 15 second bound as the handshake, so a host that drops packets can't hold an attempt for minutes.

*Tests*

Thirteen new, each failing on the v2.2.0 controller for the defect it names. The emulator can now drop every live connection, as the device's watchdog does, and stay silent after accepting a socket.

Not in here: the `SET` path still uses `asyncio.run()` from the entity's executor thread, and setup still spins on `is_connected` with no timeout, which is the cancelled wait in #79's trace. Both are next.

Twenty-four tests, all four pre-commit hooks green.
