### PR TITLE
Keep the controller on the entry, name entities from the device, add diagnostics

### DIFF
--- a/custom_components/intesisbox/__init__.py
+++ b/custom_components/intesisbox/__init__.py
@@ -1,28 +1,34 @@
 """IntesisBox Climate Platform."""
 
+from __future__ import annotations
+
 import asyncio
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant
 
+from .intesisbox import IntesisBox
+
 DOMAIN = "intesisbox"
 PLATFORMS = ["climate"]
 
+# The controller lives on the entry for the entry's lifetime. Every platform
+# reads it from here, so there is no hand-maintained dict in hass.data to keep
+# in step with setup and unload.
+type IntesisBoxConfigEntry = ConfigEntry[IntesisBox]
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
-    """Load the saved entities."""
+
+async def async_setup_entry(hass: HomeAssistant, entry: IntesisBoxConfigEntry) -> bool:
+    """Connect to the device and load its platforms."""
     host = entry.data[CONF_HOST]
 
-    from . import intesisbox
-
-    controller = intesisbox.IntesisBox(host, loop=hass.loop)
+    controller = IntesisBox(host, loop=hass.loop)
     controller.connect()
     while not controller.is_connected:
         await asyncio.sleep(0.1)
 
-    hass.data.setdefault(DOMAIN, {})
-    hass.data[DOMAIN][entry.entry_id] = controller
+    entry.runtime_data = controller
 
     if entry.unique_id is None:
         hass.config_entries.async_update_entry(
@@ -34,8 +40,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     return True
 
 
-async def async_unload_entry(hass, entry):
-    """Unload a config entry."""
-    controller = hass.data[DOMAIN][entry.entry_id]
-    controller.stop()
-    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+async def async_unload_entry(hass: HomeAssistant, entry: IntesisBoxConfigEntry) -> bool:
+    """Unload a config entry and close its connection."""
+    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+    if unload_ok:
+        entry.runtime_data.stop()
+    return unload_ok

--- a/custom_components/intesisbox/climate.py
+++ b/custom_components/intesisbox/climate.py
@@ -30,7 +30,7 @@ from homeassistant.const import (
 from homeassistant.exceptions import PlatformNotReady
 import homeassistant.helpers.config_validation as cv
 
-from . import DOMAIN
+from . import DOMAIN, IntesisBoxConfigEntry
 from .intesisbox import IntesisBox
 
 _LOGGER = logging.getLogger(__name__)
@@ -99,10 +99,11 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     async_add_entities([IntesisBoxAC(controller, name, unique_id)], True)
 
 
-async def async_setup_entry(hass, entry, async_add_entities):
+async def async_setup_entry(
+    hass, entry: IntesisBoxConfigEntry, async_add_entities
+) -> None:
     """Add entries from config."""
-    controller = hass.data[DOMAIN][entry.entry_id]
-    async_add_entities([IntesisBoxAC(controller)], True)
+    async_add_entities([IntesisBoxAC(entry.runtime_data)], True)
 
 
 class IntesisBoxAC(ClimateEntity):
@@ -121,6 +122,12 @@ class IntesisBoxAC(ClimateEntity):
         self._deviceid = controller.device_mac_address
         self._devicename = name or controller.device_mac_address
         self._unique_id = unique_id or controller.device_mac_address
+        # From a config entry the device carries the name: the single climate
+        # entity has none of its own, so its friendly name is the device's, as
+        # it was, and renaming the device renames the entity with it. The
+        # YAML platform registers no device, so there the entity keeps its
+        # configured name as before.
+        self._attr_has_entity_name = name is None
         self._connected = controller.is_connected
         # Disable compatibility mode until 2025.1 as per https://developers.home-assistant.io/blog/2024/01/24/climate-climateentityfeatures-expanded/
         self._enable_turn_on_off_backwards_compatibility = False
@@ -175,8 +182,10 @@ class IntesisBoxAC(ClimateEntity):
         self._controller.add_update_callback(self.update_callback)
 
     @property
-    def name(self):
-        """Return the name of the AC device."""
+    def name(self) -> str | None:
+        """The configured name for a YAML entity; none from a config entry."""
+        if self._attr_has_entity_name:
+            return None
         return self._devicename
 
     @property
@@ -194,7 +203,7 @@ class IntesisBoxAC(ClimateEntity):
         """Info about the IntesisBox itself."""
         return {
             "identifiers": {(DOMAIN, self.unique_id)},
-            "name": self.name,
+            "name": self._devicename,
             "manufacturer": "Intesis",
             "model": self._controller.device_model,
             "sw_version": self._controller.firmware_version,

--- a/custom_components/intesisbox/diagnostics.py
+++ b/custom_components/intesisbox/diagnostics.py
@@ -1,0 +1,35 @@
+"""Diagnostics download for an IntesisBox config entry."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.components.diagnostics import REDACTED, async_redact_data
+from homeassistant.const import CONF_HOST
+from homeassistant.core import HomeAssistant
+
+from . import IntesisBoxConfigEntry
+
+# The address and hardware identity of a box on someone's LAN are not needed
+# to diagnose a protocol problem, and should not travel with a bug report.
+TO_REDACT = {CONF_HOST, "mac", "unique_id"}
+
+
+async def async_get_config_entry_diagnostics(
+    hass: HomeAssistant, entry: IntesisBoxConfigEntry
+) -> dict[str, Any]:
+    """Return the entry, and the controller's view of the device."""
+    # The config flow titles an entry with its host unless the user renames
+    # it, so the title would otherwise carry the address the data redacts.
+    title = entry.title if entry.title != entry.data.get(CONF_HOST) else REDACTED
+    return async_redact_data(
+        {
+            "entry": {
+                "title": title,
+                "unique_id": entry.unique_id,
+                "data": dict(entry.data),
+            },
+            "device": entry.runtime_data.diagnostics(),
+        },
+        TO_REDACT,
+    )

--- a/custom_components/intesisbox/intesisbox.py
+++ b/custom_components/intesisbox/intesisbox.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 from collections.abc import Callable
 import logging
+from typing import Any
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -481,6 +482,34 @@ class IntesisBox(asyncio.Protocol):
     def horizontal_swing(self) -> str | None:
         """Current horizontal vane setting."""
         return self._device.get(FUNCTION_VANELR)
+
+    # ------------------------------------------------------------------
+    # Diagnostics
+    # ------------------------------------------------------------------
+
+    def diagnostics(self) -> dict[str, Any]:
+        """Return a snapshot for a bug report: identity, capabilities, state.
+
+        Everything here has had to be extracted by hand from debug logs while
+        diagnosing earlier issues. Identifying fields are redacted by the
+        diagnostics platform before download.
+        """
+        return {
+            "model": self._model,
+            "firmware": self._firmversion,
+            "mac": self._mac,
+            "controller_type": self._controllerType,
+            "rssi": self._rssi,
+            "connection": self._connectionStatus,
+            "limits": {
+                "setpoint": [self._setpoint_minimum, self._setpoint_maximum],
+                "fan_speeds": list(self._fan_speed_list),
+                "modes": list(self._operation_list),
+                "vane_vertical": list(self._vertical_vane_list),
+                "vane_horizontal": list(self._horizontal_vane_list),
+            },
+            "state": dict(self._device),
+        }
 
     def _send_update_callback(self):
         """Notify all listeners that state of the thermostat has changed."""

--- a/custom_components/intesisbox/manifest.json
+++ b/custom_components/intesisbox/manifest.json
@@ -8,5 +8,6 @@
   "codeowners": ["@jnimmo"],
   "config_flow": true,
   "requirements": [],
-  "iot_class": "local_polling"
+  "iot_class": "local_polling",
+  "integration_type": "device"
 }

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -1,0 +1,68 @@
+"""Tests for the diagnostics download.
+
+A bug report used to need the device model, firmware and negotiated limits
+pulled out of debug logs by hand.
+"""
+
+from __future__ import annotations
+
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.intesisbox import DOMAIN
+from custom_components.intesisbox.diagnostics import (
+    async_get_config_entry_diagnostics,
+)
+from custom_components.intesisbox.intesisbox import IntesisBox
+from homeassistant.const import CONF_HOST
+
+MAC = "001DC9A2C911"
+
+
+async def test_diagnostics_describe_the_device_and_redact_its_identity(hass):
+    """The controller's real snapshot, with address and MAC removed."""
+    box = IntesisBox("ac-study.internal", loop=None)
+    box.data_received(
+        b"LIMITS:FANSP,[AUTO,1,2,3]\r\n"
+        b"LIMITS:SETPTEMP,[160,300]\r\n"
+        b"CHN,1:ONOFF,OFF\r\nCHN,1:ERRSTATUS,OK\r\nCHN,1:ERRCODE,0\r\n"
+    )
+    assert box._parse_id_received(
+        "TO-RC-WMP-1,001DC9A2C911,192.168.1.50,ASCII,v1.3.3,-54"
+    )
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id=MAC,
+        title="Study Air Con",
+        data={CONF_HOST: "ac-study.internal"},
+    )
+    entry.runtime_data = box
+
+    diag = await async_get_config_entry_diagnostics(hass, entry)
+
+    assert diag["entry"]["title"] == "Study Air Con"
+    assert diag["entry"]["unique_id"] == "**REDACTED**"
+    assert diag["entry"]["data"][CONF_HOST] == "**REDACTED**"
+
+    device = diag["device"]
+    assert device["mac"] == "**REDACTED**"
+    assert device["model"] == "TO-RC-WMP-1"
+    assert device["firmware"] == "v1.3.3"
+    assert device["rssi"] == "-54"
+    assert device["connection"] == "Disconnected"
+    assert device["limits"]["fan_speeds"] == ["AUTO", "1", "2", "3"]
+    assert device["limits"]["setpoint"] == [16.0, 30.0]
+    assert device["state"]["ERRSTATUS"] == "OK"
+
+
+async def test_a_default_title_is_the_host_and_is_redacted_too(hass):
+    """The config flow titles an entry with its host; that must not leak."""
+    box = IntesisBox("192.0.2.10", loop=None)
+    entry = MockConfigEntry(
+        domain=DOMAIN, unique_id=MAC, title="192.0.2.10", data={CONF_HOST: "192.0.2.10"}
+    )
+    entry.runtime_data = box
+
+    diag = await async_get_config_entry_diagnostics(hass, entry)
+
+    assert diag["entry"]["title"] == "**REDACTED**"
+    assert diag["entry"]["data"][CONF_HOST] == "**REDACTED**"

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,0 +1,145 @@
+"""Set up a config entry end-to-end through Home Assistant's loader.
+
+The controller is faked at the single point __init__ creates it; everything
+downstream, platform forwarding, runtime_data, the device registry, entity
+naming and unload, is Home Assistant's own code running against this
+integration's real modules.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.intesisbox import DOMAIN
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.const import CONF_HOST, STATE_UNAVAILABLE
+from homeassistant.helpers import device_registry as dr, entity_registry as er
+from homeassistant.setup import async_setup_component
+
+MAC = "001DC9A2C911"
+
+
+class FakeController:
+    """Stands in for IntesisBox with a handshake already completed."""
+
+    def __init__(self) -> None:
+        self.is_connected = True
+        self.device_mac_address = MAC
+        self.device_model = "TO-RC-WMP-1"
+        self.firmware_version = "v1.3.3"
+        self.operation_list = ["AUTO", "HEAT", "DRY", "COOL", "FAN"]
+        self.fan_speed_list = ["AUTO", "1", "2", "3"]
+        self.vane_vertical_list: list[str] = []
+        self.vane_horizontal_list: list[str] = []
+        self.has_swing_control = False
+        self.min_setpoint = 18.0
+        self.max_setpoint = 29.0
+        self.mode = "COOL"
+        self.fan_speed = "AUTO"
+        self.setpoint = 21.0
+        self.ambient_temperature = 24.5
+        self.vertical_swing = None
+        self.horizontal_swing = None
+        self.is_on = True
+        self.stopped = False
+        self._update_callbacks: list = []
+
+    def connect(self) -> None:
+        """Already connected."""
+
+    def stop(self) -> None:
+        """Record the shutdown."""
+        self.stopped = True
+
+    def add_update_callback(self, method) -> None:
+        """Record the entity's callback."""
+        self._update_callbacks.append(method)
+
+
+@pytest.fixture(autouse=True)
+def _custom_integrations(enable_custom_integrations):
+    """Let the harness load custom_components/intesisbox."""
+
+
+async def _set_up(hass, fake, **entry_kwargs):
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="192.0.2.10",
+        data={CONF_HOST: "192.0.2.10"},
+        **entry_kwargs,
+    )
+    entry.add_to_hass(hass)
+    with patch("custom_components.intesisbox.IntesisBox", return_value=fake):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+    return entry
+
+
+async def test_entry_stores_the_controller_and_sets_up_the_climate(hass):
+    fake = FakeController()
+    entry = await _set_up(hass, fake, unique_id=MAC)
+
+    assert entry.state is ConfigEntryState.LOADED
+    assert entry.runtime_data is fake
+    assert DOMAIN not in hass.data
+
+    # One device, identified by MAC, and the entity named after it as before.
+    device = dr.async_get(hass).async_get_device(identifiers={(DOMAIN, MAC)})
+    assert device is not None
+    assert device.name == MAC
+    assert device.model == "TO-RC-WMP-1"
+    assert device.sw_version == "v1.3.3"
+
+    state = hass.states.get("climate.001dc9a2c911")
+    assert state is not None
+    assert state.attributes["friendly_name"] == MAC
+    assert state.state == "cool"
+    assert state.attributes["current_temperature"] == 24.5
+    assert er.async_get(hass).async_get("climate.001dc9a2c911").device_id == device.id
+
+
+async def test_an_entry_without_a_unique_id_gets_the_mac(hass):
+    fake = FakeController()
+    entry = await _set_up(hass, fake)
+    assert entry.unique_id == MAC
+
+
+async def test_unload_stops_the_controller(hass):
+    fake = FakeController()
+    entry = await _set_up(hass, fake, unique_id=MAC)
+
+    assert await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert entry.state is ConfigEntryState.NOT_LOADED
+    assert fake.stopped is True
+    assert hass.states.get("climate.001dc9a2c911").state == STATE_UNAVAILABLE
+
+
+async def test_a_failed_platform_unload_keeps_the_controller_running(hass):
+    fake = FakeController()
+    entry = await _set_up(hass, fake, unique_id=MAC)
+    with patch.object(
+        hass.config_entries, "async_unload_platforms", new=AsyncMock(return_value=False)
+    ):
+        assert not await hass.config_entries.async_unload(entry.entry_id)
+    assert fake.stopped is False
+
+
+async def test_a_yaml_platform_keeps_its_configured_name(hass):
+    """The YAML path registers no device, so the entity keeps its own name."""
+    fake = FakeController()
+    with patch("custom_components.intesisbox.intesisbox.IntesisBox", return_value=fake):
+        assert await async_setup_component(
+            hass,
+            "climate",
+            {"climate": {"platform": DOMAIN, "host": "192.0.2.10", "name": "Lounge"}},
+        )
+        await hass.async_block_till_done()
+
+    state = hass.states.get("climate.lounge")
+    assert state is not None
+    assert state.attributes["friendly_name"] == "Lounge"


### PR DESCRIPTION
Three quality-scale items that don't depend on the transport work, so they can go in alongside it.

*runtime_data*

The controller lived in a dict under `hass.data` that setup filled and unload emptied by hand. It now lives on the config entry as `runtime_data`, typed, so every platform reads it from one place and there's nothing to keep in step. Unload stops the controller only once the platforms have actually unloaded; before, it closed the socket first and then unloaded entities against a dead connection.

*has_entity_name*

From a config entry the climate entity now declares `has_entity_name` and carries no name of its own, so its friendly name is the device's. The device keeps the name it had, so nothing renames for anyone; what changes is that renaming the device now renames the entity with it, and later entities on the same device get sensible names without more code. The YAML platform registers no device, so there the entity keeps its configured name exactly as before; there's a test for that path.

*Diagnostics*

A diagnostics download returns the entry and the controller's view of the device: model, firmware, controller generation, signal strength, connection state, the negotiated limits and the last status. Every one of those has had to be pulled out of debug logs by hand while diagnosing earlier issues. The host, MAC and unique id are redacted, and so is the entry title when it's the host, which is what the config flow titles an entry by default.

The manifest gains `integration_type: device`. `iot_class` stays `local_polling` until the entity stops polling, which is a later PR.

*Tests*

Seven new, going through Home Assistant's own loader with the controller faked at the one point setup creates it: a config entry sets up, stores the controller, keeps its entity id and name; an entry with no unique id gets the MAC; unload stops the controller and a failed platform unload doesn't; a YAML entity keeps its configured name; the diagnostics snapshot and both redactions. On `main`, the two diagnostics tests can't be collected because the module doesn't exist, four fail on the missing `runtime_data`, and the YAML one passes, which is the point of it.

Independent of #83. Eighteen tests, all four pre-commit hooks green.
